### PR TITLE
Add missing header file.

### DIFF
--- a/src/is_fileio.h
+++ b/src/is_fileio.h
@@ -22,6 +22,7 @@
 #define IS_FILEIO_H
 
 #include <physfs.h>
+#include <stdarg.h>
 
 typedef PHYSFS_File *   IS_FileHdl;
 


### PR DESCRIPTION
Needed for va_list.

Fixes the build on NetBSD.